### PR TITLE
Supports blur/focus event delegation by forcing capture=true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/test.bundle.js

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ var fn = delegate.bind(ul, 'li a', 'click', function(e){
 
   Unbind.
 
+## Tests
+
+* Run `npm test`.
+* Open `test/index.html` in a browser.
+* Open the js console and verify that interacting with the elements works as they say they should.
+
 ## License
 
   MIT

--- a/index.js
+++ b/index.js
@@ -19,7 +19,13 @@ var closest = require('closest')
  * @api public
  */
 
+// Some events don't bubble, so we want to bind to the capture phase instead
+// when delegating.
+var forceCaptureEvents = ['focus', 'blur'];
+
 exports.bind = function(el, selector, type, fn, capture){
+  if (forceCaptureEvents.indexOf(type) !== -1) capture = true;
+
   return event.bind(el, type, function(e){
     var target = e.target || e.srcElement;
     e.delegateTarget = closest(target, selector, true, el);
@@ -38,5 +44,7 @@ exports.bind = function(el, selector, type, fn, capture){
  */
 
 exports.unbind = function(el, type, fn, capture){
+  if (forceCaptureEvents.indexOf(type) !== -1) capture = true;
+
   event.unbind(el, type, fn, capture);
 };

--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/HenrikJoreteg/delegate.git"
+  },
+  "devDependencies": {
+    "browserify": "^3.33.0"
+  },
+  "scripts": {
+    "test": "browserify test/test.js > test/test.bundle.js && echo 'Now open test/index.html in a browser to test'"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -4,52 +4,37 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   </head>
   <body>
-    <ul>
-      <li><a href="#">One</a></li>
-      <li><a href="#">Two</a></li>
-      <li><a href="#">Three</a></li>
+
+    <h1> Delegate tests</h1>
+
+    <p>Open the console, and verify that interacting with the elements logs output as expected by their descriptions.</p>
+
+    <h2>Basic binding</h2>
+
+    <ul class='basic-test'>
+      <li><a class='unlimited' href="#">I can be clicked unlimited times</a></li>
+      <li><a class='unlimited' href="#">I can be clicked unlimited times</a></li>
+
+      <li>I don't have a &lt;a&gt; so am unclickable</li>
+
+      <li><a class='five-times' href="#">I can be clicked 5 times</a></li>
     </ul>
 
-    <ul id="list-two">
-      <li><a href="#">One</a></li>
+    <h2>Multiple events</h2>
+    <p>Bind two events, one to "li a" and one to "li.foo a", give one element the foo class, but not the other.</p>
+    <ul class='multiple-test'>
+      <li><a href='#'>Bound to li, triggers 1 event</a></li>
+      <li class='foo'><a href='#'>Bound to li.foo, triggers both events</a></li>
     </ul>
 
-    <ul>
-      <li><span>one</span></li>
+
+    <h2>Blur/Focus events</h2>
+
+    <ul class='blur-focus-test'>
+      <li class='focus'>This triggers on focus: <input placeholder='focus me'></li>
+      <li class='blur'>This triggers on blur: <input placeholder='blur me'></li>
     </ul>
 
-    <button>Button</button>
-
-    <script src="../build/build.js"></script>
-
-    <script>
-      var delegate = require('delegate');
-      var uls = document.querySelectorAll('ul');
-      var n = 0;
-
-      var fn = delegate.bind(uls[0], 'li a', 'click', function(e){
-        console.log(e.target);
-        if (++n >= 3) {
-          console.log('unbind');
-          delegate.unbind(uls[0], 'click', fn, false);
-        }
-      }, false);
-
-      var fn2 = delegate.bind(uls[1], 'li a', 'click', function(e){
-        console.log(e.target);
-        if (++n >= 8) {
-          console.log('unbind');
-          delegate.unbind(uls[1], 'click', fn2, false);
-        }
-      }, false);
-
-      var fn3 = delegate.bind(uls[2], 'li', 'click', function(e){
-        console.log(e.target);
-        if (++n >= 8) {
-          console.log('unbind');
-          delegate.unbind(uls[2], 'click', fn2, false);
-        }
-      }, false);
-    </script>
+    <script src="./test.bundle.js"></script>
   </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,51 @@
+var delegate = require('../index');
+
+var test = function (name, fn) { fn(); };
+
+test('basic tests', function () {
+  var ul = document.querySelector('ul.basic-test');
+
+  test('binds to child elements', function () {
+    delegate.bind(ul, 'li a.unlimited', 'click', function (e) {
+      console.log('Clicked:', e.target);
+    });
+  });
+
+  test('unbinds', function () {
+    var n = 0;
+    var fn = delegate.bind(ul, 'li a.five-times', 'click', function (e) {
+      if (++n >= 5) {
+        delegate.unbind(ul, 'click', fn, false);
+      }
+      console.log("Clicked " + n + " times:", e.target);
+    }, false);
+  });
+});
+
+test('multiple events to same element', function () {
+    var ul = document.querySelector('ul.multiple-test');
+
+    delegate.bind(ul, 'li a', 'click', function (e) {
+        console.log('');
+        console.log('li event triggered on', e.target);
+    });
+    delegate.bind(ul, 'li.foo a', 'click', function (e) {
+        console.log('li.foo event triggered on', e.target);
+    });
+});
+
+
+test('Blur and Focus tests', function () {
+  var ul = document.querySelector('ul.blur-focus-test');
+
+  test('it binds to multiple delegate targets', function () {
+    delegate.bind(ul, 'li.focus input', 'focus', function (e) {
+      console.log("Focussed", e.target);
+    }, false);
+
+    delegate.bind(ul, 'li.blur input', 'blur', function (e) {
+      console.log("Blurred", e.target);
+    }, false);
+  });
+});
+


### PR DESCRIPTION
Blur/focus events don't bubble, so the only way to
delegate them is to listen to the capture events
instead as per: https://developer.mozilla.org/en-US/docs/Web/Reference/Events/focus#Event_delegation
