### PR TITLE
Change dependency `event` to `component-event` as this is the actual module name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  */
 
 var closest = require('closest')
-  , event = require('event');
+  , event = require('component-event');
 
 /**
  * Delegate event `type` to `selector`


### PR DESCRIPTION
I ran into this when I was trying to test a package that was using ampersand-view with [jasmine-node](https://github.com/mhevery/jasmine-node). Did I miss something?  
